### PR TITLE
Add Cookie.load_buffers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ travis-ci = { repository = "robo9k/rust-magic" }
 name = "magic"
 
 [dependencies]
-magic-sys = "0.2.0"
+magic-sys = "0.2.1"
 bitflags = "0.7.0"
 libc = "0.2.13"
 


### PR DESCRIPTION
Adds a binding for `magic_load_buffers`. Requires [rust-magic-sys#10](https://github.com/robo9k/rust-magic-sys/pull/10).

Intended to be used like this:

```rust
let cookie = magic::Cookie::open(magic::CookieFlags::default());
let magic_data = std::fs::read("/usr/share/misc/magic.mgc").unwrap();
let buffers = vec![magic_data.as_slice()];
cookie.load_buffers(&*buffers).unwrap();
println!("{:?}", cookie.file("/usr/share/misc/magic.mgc"));
```