### PR TITLE
Determine and document minimum supported rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,18 @@ version = "0.12.2"
 exclude = [
     ".gitignore",
 ]
+rust-version = "1.42"
+
+[package.metadata]
+msrv = "1.42.0"
 
 [lib]
 name = "magic"
 
 [dependencies]
-magic-sys = "0.2.0"
 bitflags = "0.7.0"
 libc = "0.2.13"
+magic-sys = "0.2.0"
 
 [dev-dependencies]
 regex = "0.1.71"

--- a/README.md
+++ b/README.md
@@ -21,10 +21,13 @@ magic = "0.*"
 
 Then use the [`magic` crate](https://crates.io/crates/magic) according to [its documentation](https://docs.rs/magic/#usage-example).
 
+# MSRV
+
+The Minimum Supported Rust Version (MSRV) is Rust 1.42 or higher.
+
+This version might be changed in the future, but it will be done with a crate version bump.
 
 # Requirements
-
-Needs `rustc 1.6 stable` or later. [Create an issue](https://github.com/robo9k/rust-magic/issues/new) if it does not work on current stable.
 
 By default compiling `rust-magic` will search your system library paths for a version of `libmagic.so`. If you're cross-compiling, or need more control over which library is selected, see [how to build `rust-magic-sys`](https://github.com/robo9k/rust-magic-sys#building).
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.42.0"


### PR DESCRIPTION
This was done using `cargo msrv` with `cargo test` on Linux.

CI has not been adjusted to have a build matrix for MSRV. MSRV and current stable should be built for all platforms in a future merge request.

Also see robo9k/rust-magic-sys#14