### PR TITLE
Update all dependencies to their latest stable versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,18 +19,21 @@ version = "0.12.2"
 exclude = [
     ".gitignore",
 ]
-rust-version = "1.42"
+rust-version = "1.46"
 
 [package.metadata]
-msrv = "1.42.0"
+msrv = "1.46.0"
 
 [lib]
 name = "magic"
 
 [dependencies]
-bitflags = "0.7.0"
-libc = "0.2.13"
-magic-sys = "0.2.0"
+bitflags = "1.3.2"
+magic-sys = "0.2.1"
+
+[dependencies.libc]
+version = "0.2.105"
+default-features = false
 
 [dev-dependencies]
-regex = "0.1.71"
+regex = "1.5.4"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then use the [`magic` crate](https://crates.io/crates/magic) according to [its d
 
 # MSRV
 
-The Minimum Supported Rust Version (MSRV) is Rust 1.42 or higher.
+The Minimum Supported Rust Version (MSRV) is Rust 1.46 or higher.
 
 This version might be changed in the future, but it will be done with a crate version bump.
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.42.0"
+channel = "1.46.0"


### PR DESCRIPTION
This updates both `depedencies` and `dev-dependencies` to their latest stable versions.
It does not update `magic-sys` to `0.3.0-alpha.1`, as that requires more integration.
`regex` test could probably be removed together with the `version()` functionality.

This is a breaking change:
* MSRV from 1.42 to 1.46 due to `bitflags!` update
* `bitflags!` update changed generated struct and constants
* `magic::flags` module is no longer required for `bitflags!` and has been removed