### PR TITLE
Implement more comprehensive errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,9 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 bitflags = "1.3.2"
-magic-sys = "0.3.0-alpha.2"
+magic-sys = "0.3.0-alpha.3"
+thiserror = "1.0.30"
+errno = "0.2.8"
 
 [dependencies.libc]
 version = "0.2.105"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,7 @@ fn db_filenames<P: AsRef<Path>>(filenames: &[P]) -> *const c_char {
 }
 
 /// Generic `libmagic` error type for successfuly opened [`Cookie`] instances
+#[doc(alias = "magic_error")]
 #[derive(Error, Debug)]
 #[error("`libmagic` error ({}): {explanation}", match .errno {
     Some(errno) => format!("OS errno: {}", errno),
@@ -328,24 +329,6 @@ impl Cookie {
             } else {
                 let slice = CStr::from_ptr(str).to_bytes();
                 Ok(str::from_utf8(slice).unwrap().to_string())
-            }
-        }
-    }
-
-    /// Returns a textual explanation of the last error, if any
-    ///
-    /// You should not need to call this, since you can use the `MagicError` in
-    /// the `Result` returned by the other functions.
-    // TODO: Remove this entirely?
-    #[doc(alias = "magic_error")]
-    pub fn error(&self) -> Option<String> {
-        unsafe {
-            let str = self::ffi::magic_error(self.cookie);
-            if str.is_null() {
-                None
-            } else {
-                let slice = CStr::from_ptr(str).to_bytes();
-                Some(str::from_utf8(slice).unwrap().to_string())
             }
         }
     }


### PR DESCRIPTION
This changes the previously rather limited error struct type into something more comprehensive.

* `MagicError` is now a non-exhaustive enum, this is a breaking semver change.
* Dependencies `thiserror` and `errno` were added, but they are not part of the public API.
* `Cookie.error` was removed, this is a breaking semver change.
* `Cookie.set_flags` now returns `Result` (see #33), , this is a breaking semver change.