### PR TITLE
Isolate `unsafe` into FFI module

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -184,3 +184,15 @@ pub(crate) fn load_buffers(
         ),
     }
 }
+
+pub(crate) fn open(flags: libc::c_int) -> Result<self::libmagic::magic_t, LibmagicError> {
+    let cookie = unsafe { self::libmagic::magic_open(flags) };
+
+    if cookie.is_null() {
+        Err(LibmagicError::Open {
+            errno: errno::errno(),
+        })
+    } else {
+        Ok(cookie)
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -140,3 +140,17 @@ pub(crate) fn list(
         res => panic!("libmagic API violation: `magic_list()` returned {}", res),
     }
 }
+
+pub(crate) fn load(
+    cookie: self::libmagic::magic_t,
+    filename: Option<&std::ffi::CStr>,
+) -> Result<(), LibmagicError> {
+    let filename_ptr = filename.map_or_else(std::ptr::null, std::ffi::CStr::as_ptr);
+    let res = unsafe { self::libmagic::magic_load(cookie, filename_ptr) };
+
+    match res {
+        0 => Ok(()),
+        -1 => Err(last_error(cookie).unwrap()),
+        res => panic!("libmagic API violation: `magic_load()` returned {}", res),
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -112,3 +112,17 @@ pub(crate) fn check(
         res => panic!("libmagic API violation: `magic_check()` returned {}", res),
     }
 }
+
+pub(crate) fn compile(
+    cookie: self::libmagic::magic_t,
+    filename: Option<&std::ffi::CStr>,
+) -> Result<(), LibmagicError> {
+    let filename_ptr = filename.map_or_else(std::ptr::null, std::ffi::CStr::as_ptr);
+    let res = unsafe { self::libmagic::magic_compile(cookie, filename_ptr) };
+
+    match res {
+        0 => Ok(()),
+        -1 => Err(last_error(cookie).unwrap()),
+        res => panic!("libmagic API violation: `magic_compile()` returned {}", res),
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -30,6 +30,8 @@ pub(crate) enum LibmagicError {
         #[source]
         errno: Option<errno::Errno>,
     },
+    #[error("Error calling `magic_setflags`, unsupported flags: {flags}")]
+    UnsupportedFlags { flags: libc::c_int },
 }
 
 pub(crate) fn last_error(cookie: self::libmagic::magic_t) -> Option<LibmagicError> {
@@ -83,5 +85,16 @@ pub(crate) fn buffer(
     } else {
         let c_str = unsafe { std::ffi::CStr::from_ptr(res) };
         Ok(c_str.into())
+    }
+}
+
+pub(crate) fn setflags(
+    cookie: self::libmagic::magic_t,
+    flags: libc::c_int,
+) -> Result<(), LibmagicError> {
+    let ret = unsafe { self::libmagic::magic_setflags(cookie, flags) };
+    match ret {
+        -1 => Err(LibmagicError::UnsupportedFlags { flags }),
+        _ => Ok(()),
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -126,3 +126,17 @@ pub(crate) fn compile(
         res => panic!("libmagic API violation: `magic_compile()` returned {}", res),
     }
 }
+
+pub(crate) fn list(
+    cookie: self::libmagic::magic_t,
+    filename: Option<&std::ffi::CStr>,
+) -> Result<(), LibmagicError> {
+    let filename_ptr = filename.map_or_else(std::ptr::null, std::ffi::CStr::as_ptr);
+    let res = unsafe { self::libmagic::magic_list(cookie, filename_ptr) };
+
+    match res {
+        0 => Ok(()),
+        -1 => Err(last_error(cookie).unwrap()),
+        res => panic!("libmagic API violation: `magic_list()` returned {}", res),
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5,6 +5,53 @@
 #![allow(unsafe_code)]
 
 extern crate magic_sys as libmagic;
+extern crate thiserror;
+
+use std::ffi::CStr;
+
+#[non_exhaustive]
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum LibmagicError {
+    /// Error during `magic_open`
+    #[error("Error calling `magic_open`, errno: {errno}")]
+    Open {
+        #[source]
+        errno: errno::Errno,
+    },
+
+    /// Error for opened `magic_t` instance
+    #[error("Error for cookie call ({}): {explanation}", match .errno {
+        Some(errno) => format!("OS errno: {}", errno),
+        None => "no OS errno".to_string(),
+    })]
+    Cookie {
+        explanation: String,
+        #[source]
+        errno: Option<errno::Errno>,
+    },
+}
+
+pub(crate) fn last_error(cookie: self::libmagic::magic_t) -> Option<LibmagicError> {
+    unsafe {
+        let error = self::libmagic::magic_error(cookie);
+        let errno = self::libmagic::magic_errno(cookie);
+        if error.is_null() {
+            None
+        } else {
+            let slice = CStr::from_ptr(error).to_bytes();
+            Some(
+                LibmagicError::Cookie {
+                    explanation: std::str::from_utf8(slice).unwrap().to_string(),
+                    errno: match errno {
+                        0 => None,
+                        _ => Some(errno::Errno(errno)),
+                    },
+                }
+                .into(),
+            )
+        }
+    }
+}
 
 pub(crate) fn close(cookie: self::libmagic::magic_t) {
     unsafe { self::libmagic::magic_close(cookie) }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,0 +1,11 @@
+//! Internal Foreign Function Interface module for `magic_sys` / `libmagic`
+//!
+//! Contains `unsafe` as a medium level binding.
+
+#![allow(unsafe_code)]
+
+extern crate magic_sys as libmagic;
+
+pub(crate) fn close(cookie: self::libmagic::magic_t) {
+    unsafe { self::libmagic::magic_close(cookie) }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,18 +311,10 @@ impl Cookie {
     /// Returns a textual description of the contents of the `filename`
     #[doc(alias = "magic_file")]
     pub fn file<P: AsRef<Path>>(&self, filename: P) -> Result<String, MagicError> {
-        let cookie = self.cookie;
-        let f = CString::new(filename.as_ref().to_string_lossy().into_owned())
-            .unwrap()
-            .into_raw();
-        unsafe {
-            let str = self::libmagic::magic_file(cookie, f);
-            if str.is_null() {
-                Err(self.magic_failure())
-            } else {
-                let slice = CStr::from_ptr(str).to_bytes();
-                Ok(str::from_utf8(slice).unwrap().to_string())
-            }
+        let c_string = CString::new(filename.as_ref().to_string_lossy().into_owned()).unwrap();
+        match self::ffi::file(self.cookie, c_string.as_c_str()) {
+            Ok(res) => Ok(res.to_string_lossy().to_string()),
+            Err(err) => Err(err.into()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ extern crate static_assertions;
 extern crate errno;
 extern crate thiserror;
 
-use libc::{c_int, size_t};
-use std::ffi::{CStr, CString};
+use libc::c_int;
+use std::ffi::CString;
 use std::path::Path;
 use std::ptr;
 use std::str;
@@ -332,12 +332,13 @@ impl Cookie {
     /// Overwrites any previously set flags, e.g. those from `load()`.
     #[doc(alias = "magic_setflags")]
     pub fn set_flags(&self, flags: self::CookieFlags) -> Result<(), MagicError> {
-        let ret = unsafe { self::libmagic::magic_setflags(self.cookie, flags.bits()) };
+        let ret = self::ffi::setflags(self.cookie, flags.bits());
         match ret {
-            -1 => Err(MagicError::LibmagicFlagUnsupported(
+            // according to `libmagic` man page this is the only flag that could be unsupported
+            Err(_) => Err(MagicError::LibmagicFlagUnsupported(
                 CookieFlags::PRESERVE_ATIME,
             )),
-            _ => Ok(()),
+            Ok(_) => Ok(()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,20 +372,11 @@ impl Cookie {
     /// Dumps all magic entries in the given database `filenames` in a human readable format
     #[doc(alias = "magic_list")]
     pub fn list<P: AsRef<Path>>(&self, filenames: &[P]) -> Result<(), MagicError> {
-        let cookie = self.cookie;
         let db_filenames = db_filenames(filenames)?;
-        let ret;
 
-        unsafe {
-            ret = self::libmagic::magic_list(
-                cookie,
-                db_filenames.map_or_else(ptr::null, |c| c.into_raw()),
-            );
-        }
-        if 0 == ret {
-            Ok(())
-        } else {
-            Err(self.magic_failure())
+        match self::ffi::list(self.cookie, db_filenames.as_deref()) {
+            Err(err) => Err(err.into()),
+            Ok(_) => Ok(()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,20 +361,11 @@ impl Cookie {
     /// The compiled files created are named from the `basename` of each file argument with '.mgc' appended to it.
     #[doc(alias = "magic_compile")]
     pub fn compile<P: AsRef<Path>>(&self, filenames: &[P]) -> Result<(), MagicError> {
-        let cookie = self.cookie;
         let db_filenames = db_filenames(filenames)?;
-        let ret;
 
-        unsafe {
-            ret = self::libmagic::magic_compile(
-                cookie,
-                db_filenames.map_or_else(ptr::null, |c| c.into_raw()),
-            );
-        }
-        if 0 == ret {
-            Ok(())
-        } else {
-            Err(self.magic_failure())
+        match self::ffi::compile(self.cookie, db_filenames.as_deref()) {
+            Err(err) => Err(err.into()),
+            Ok(_) => Ok(()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //!
 
 extern crate libc;
-extern crate magic_sys as ffi;
+extern crate magic_sys as libmagic;
 #[macro_use]
 extern crate bitflags;
 #[cfg(test)]
@@ -99,49 +99,49 @@ bitflags! {
         ///
         /// NOTE: Those messages are printed by `libmagic` itself, no this Rust crate.
         #[doc(alias = "MAGIC_DEBUG")]
-        const DEBUG             = self::ffi::MAGIC_DEBUG;
+        const DEBUG             = self::libmagic::MAGIC_DEBUG;
 
         /// If the file queried is a symlink, follow it
         #[doc(alias = "MAGIC_SYMLINK")]
-        const SYMLINK           = self::ffi::MAGIC_SYMLINK;
+        const SYMLINK           = self::libmagic::MAGIC_SYMLINK;
 
         /// If the file is compressed, unpack it and look at the contents
         #[doc(alias = "MAGIC_COMPRESS")]
-        const COMPRESS          = self::ffi::MAGIC_COMPRESS;
+        const COMPRESS          = self::libmagic::MAGIC_COMPRESS;
 
         /// If the file is a block or character special device, then open the device and try to look in its contents
         #[doc(alias = "MAGIC_DEVICES")]
-        const DEVICES           = self::ffi::MAGIC_DEVICES;
+        const DEVICES           = self::libmagic::MAGIC_DEVICES;
 
         /// Return a MIME type string, instead of a textual description
         #[doc(alias = "MAGIC_MIME_TYPE")]
-        const MIME_TYPE         = self::ffi::MAGIC_MIME_TYPE;
+        const MIME_TYPE         = self::libmagic::MAGIC_MIME_TYPE;
 
         /// Return all matches, not just the first
         #[doc(alias = "MAGIC_CONTINUE")]
-        const CONTINUE          = self::ffi::MAGIC_CONTINUE;
+        const CONTINUE          = self::libmagic::MAGIC_CONTINUE;
 
         /// Check the magic database for consistency and print warnings to `stderr`
         ///
         /// NOTE: Those warnings are printed by `libmagic` itself, no this Rust crate.
         #[doc(alias = "MAGIC_CHECK")]
-        const CHECK             = self::ffi::MAGIC_CHECK;
+        const CHECK             = self::libmagic::MAGIC_CHECK;
 
         /// On systems that support `utime(2)` or `utimes(2)`, attempt to preserve the access time of files analyzed
         #[doc(alias = "MAGIC_PRESERVE_ATIME")]
-        const PRESERVE_ATIME    = self::ffi::MAGIC_PRESERVE_ATIME;
+        const PRESERVE_ATIME    = self::libmagic::MAGIC_PRESERVE_ATIME;
 
         /// Don't translate unprintable characters to a `\\ooo` octal representation
         #[doc(alias = "MAGIC_RAW")]
-        const RAW               = self::ffi::MAGIC_RAW;
+        const RAW               = self::libmagic::MAGIC_RAW;
 
         /// Treat operating system errors while trying to open files and follow symlinks as real errors, instead of printing them in the magic buffer
         #[doc(alias = "MAGIC_ERROR")]
-        const ERROR             = self::ffi::MAGIC_ERROR;
+        const ERROR             = self::libmagic::MAGIC_ERROR;
 
         /// Return a MIME encoding, instead of a textual description
         #[doc(alias = "MAGIC_MIME_ENCODING")]
-        const MIME_ENCODING     = self::ffi::MAGIC_MIME_ENCODING;
+        const MIME_ENCODING     = self::libmagic::MAGIC_MIME_ENCODING;
 
         /// A shorthand for `MIME_TYPE | MIME_ENCODING`
         #[doc(alias = "MAGIC_MIME")]
@@ -150,15 +150,15 @@ bitflags! {
 
         /// Return the Apple creator and type
         #[doc(alias = "MAGIC_APPLE")]
-        const APPLE             = self::ffi::MAGIC_APPLE;
+        const APPLE             = self::libmagic::MAGIC_APPLE;
 
         /// Return a slash-separated list of extensions for this file type
         #[doc(alias = "MAGIC_EXTENSION")]
-        const EXTENSION         = self::ffi::MAGIC_EXTENSION;
+        const EXTENSION         = self::libmagic::MAGIC_EXTENSION;
 
         /// Don't report on compression, only report about the uncompressed data
         #[doc(alias = "MAGIC_COMPRESS_TRANSP")]
-        const COMPRESS_TRANSP   = self::ffi::MAGIC_COMPRESS_TRANSP;
+        const COMPRESS_TRANSP   = self::libmagic::MAGIC_COMPRESS_TRANSP;
 
         /// A shorthand for `EXTENSION | MIME | APPLE`
         #[doc(alias = "MAGIC_NODESC")]
@@ -168,47 +168,47 @@ bitflags! {
 
         /// Don't look inside compressed files
         #[doc(alias = "MAGIC_NO_CHECK_COMPRESS")]
-        const NO_CHECK_COMPRESS = self::ffi::MAGIC_NO_CHECK_COMPRESS;
+        const NO_CHECK_COMPRESS = self::libmagic::MAGIC_NO_CHECK_COMPRESS;
 
         /// Don't examine tar files
         #[doc(alias = "MAGIC_NO_CHECK_TAR")]
-        const NO_CHECK_TAR      = self::ffi::MAGIC_NO_CHECK_TAR;
+        const NO_CHECK_TAR      = self::libmagic::MAGIC_NO_CHECK_TAR;
 
         /// Don't consult magic files
         #[doc(alias = "MAGIC_NO_CHECK_SOFT")]
-        const NO_CHECK_SOFT     = self::ffi::MAGIC_NO_CHECK_SOFT;
+        const NO_CHECK_SOFT     = self::libmagic::MAGIC_NO_CHECK_SOFT;
 
         /// Check for EMX application type (only on EMX)
         #[doc(alias = "MAGIC_NO_CHECK_APPTYPE")]
-        const NO_CHECK_APPTYPE  = self::ffi::MAGIC_NO_CHECK_APPTYPE;
+        const NO_CHECK_APPTYPE  = self::libmagic::MAGIC_NO_CHECK_APPTYPE;
 
         /// Don't print ELF details
         #[doc(alias = "MAGIC_NO_CHECK_ELF")]
-        const NO_CHECK_ELF      = self::ffi::MAGIC_NO_CHECK_ELF;
+        const NO_CHECK_ELF      = self::libmagic::MAGIC_NO_CHECK_ELF;
 
         /// Don't check for various types of text files
         #[doc(alias = "MAGIC_NO_CHECK_TEXT")]
-        const NO_CHECK_TEXT     = self::ffi::MAGIC_NO_CHECK_TEXT;
+        const NO_CHECK_TEXT     = self::libmagic::MAGIC_NO_CHECK_TEXT;
 
         /// Don't get extra information on MS Composite Document Files
         #[doc(alias = "MAGIC_NO_CHECK_CDF")]
-        const NO_CHECK_CDF      = self::ffi::MAGIC_NO_CHECK_CDF;
+        const NO_CHECK_CDF      = self::libmagic::MAGIC_NO_CHECK_CDF;
 
         /// Don't examine CSV files
         #[doc(alias = "MAGIC_NO_CHECK_CSV")]
-        const NO_CHECK_CSV      = self::ffi::MAGIC_NO_CHECK_CSV;
+        const NO_CHECK_CSV      = self::libmagic::MAGIC_NO_CHECK_CSV;
 
         /// Don't look for known tokens inside ascii files
         #[doc(alias = "MAGIC_NO_CHECK_TOKENS")]
-        const NO_CHECK_TOKENS   = self::ffi::MAGIC_NO_CHECK_TOKENS;
+        const NO_CHECK_TOKENS   = self::libmagic::MAGIC_NO_CHECK_TOKENS;
 
         /// Don't check text encodings
         #[doc(alias = "MAGIC_NO_CHECK_ENCODING")]
-        const NO_CHECK_ENCODING = self::ffi::MAGIC_NO_CHECK_ENCODING;
+        const NO_CHECK_ENCODING = self::libmagic::MAGIC_NO_CHECK_ENCODING;
 
         /// Don't examine JSON files
         #[doc(alias = "MAGIC_NO_CHECK_JSON")]
-        const NO_CHECK_JSON     = self::ffi::MAGIC_NO_CHECK_JSON;
+        const NO_CHECK_JSON     = self::libmagic::MAGIC_NO_CHECK_JSON;
 
         /// No built-in tests; only consult the magic file
         #[doc(alias = "MAGIC_NO_CHECK_BUILTIN")]
@@ -296,14 +296,14 @@ pub enum MagicError {
 #[doc(alias = "magic_t")]
 #[doc(alias = "magic_set")]
 pub struct Cookie {
-    cookie: self::ffi::magic_t,
+    cookie: self::libmagic::magic_t,
 }
 
 impl Drop for Cookie {
     /// Closes the magic database and deallocates any resources used
     #[doc(alias = "magic_close")]
     fn drop(&mut self) {
-        unsafe { self::ffi::magic_close(self.cookie) }
+        unsafe { self::libmagic::magic_close(self.cookie) }
     }
 }
 
@@ -312,8 +312,8 @@ impl Cookie {
         let cookie = self.cookie;
 
         unsafe {
-            let error = self::ffi::magic_error(cookie);
-            let errno = self::ffi::magic_errno(cookie);
+            let error = self::libmagic::magic_error(cookie);
+            let errno = self::libmagic::magic_errno(cookie);
             if error.is_null() {
                 None
             } else {
@@ -347,7 +347,7 @@ impl Cookie {
             .unwrap()
             .into_raw();
         unsafe {
-            let str = self::ffi::magic_file(cookie, f);
+            let str = self::libmagic::magic_file(cookie, f);
             if str.is_null() {
                 Err(self.magic_failure())
             } else {
@@ -363,7 +363,7 @@ impl Cookie {
         let buffer_len = buffer.len() as size_t;
         let pbuffer = buffer.as_ptr();
         unsafe {
-            let str = self::ffi::magic_buffer(self.cookie, pbuffer, buffer_len);
+            let str = self::libmagic::magic_buffer(self.cookie, pbuffer, buffer_len);
             if str.is_null() {
                 Err(self.magic_failure())
             } else {
@@ -378,7 +378,7 @@ impl Cookie {
     /// Overwrites any previously set flags, e.g. those from `load()`.
     #[doc(alias = "magic_setflags")]
     pub fn set_flags(&self, flags: self::CookieFlags) -> Result<(), MagicError> {
-        let ret = unsafe { self::ffi::magic_setflags(self.cookie, flags.bits()) };
+        let ret = unsafe { self::libmagic::magic_setflags(self.cookie, flags.bits()) };
         match ret {
             -1 => Err(MagicError::LibmagicFlagUnsupported(
                 CookieFlags::PRESERVE_ATIME,
@@ -398,7 +398,7 @@ impl Cookie {
         let ret;
 
         unsafe {
-            ret = self::ffi::magic_check(
+            ret = self::libmagic::magic_check(
                 cookie,
                 db_filenames.map_or_else(ptr::null, |c| c.into_raw()),
             );
@@ -420,7 +420,7 @@ impl Cookie {
         let ret;
 
         unsafe {
-            ret = self::ffi::magic_compile(
+            ret = self::libmagic::magic_compile(
                 cookie,
                 db_filenames.map_or_else(ptr::null, |c| c.into_raw()),
             );
@@ -440,7 +440,7 @@ impl Cookie {
         let ret;
 
         unsafe {
-            ret = self::ffi::magic_list(
+            ret = self::libmagic::magic_list(
                 cookie,
                 db_filenames.map_or_else(ptr::null, |c| c.into_raw()),
             );
@@ -477,7 +477,7 @@ impl Cookie {
         let ret;
 
         unsafe {
-            ret = self::ffi::magic_load(
+            ret = self::libmagic::magic_load(
                 cookie,
                 db_filenames.map_or_else(ptr::null, |c| c.into_raw()),
             );
@@ -512,7 +512,7 @@ impl Cookie {
         }
 
         unsafe {
-            ret = self::ffi::magic_load_buffers(
+            ret = self::libmagic::magic_load_buffers(
                 cookie,
                 ffi_buffers.as_mut_ptr() as *mut *mut libc::c_void,
                 ffi_sizes.as_mut_ptr(),
@@ -534,7 +534,7 @@ impl Cookie {
     pub fn open(flags: self::CookieFlags) -> Result<Cookie, MagicError> {
         let cookie;
         unsafe {
-            cookie = self::ffi::magic_open((flags | self::CookieFlags::ERROR).bits());
+            cookie = self::libmagic::magic_open((flags | self::CookieFlags::ERROR).bits());
         }
         if cookie.is_null() {
             Err(LibmagicOpenError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //! This crate has not been audited nor is it ready for production use.
 //!
 
-#![warn(unsafe_code)]
+#![deny(unsafe_code)]
 
 extern crate libc;
 extern crate magic_sys as libmagic;
@@ -422,17 +422,9 @@ impl Cookie {
     /// This does not `load()` any databases yet.
     #[doc(alias = "magic_open")]
     pub fn open(flags: self::CookieFlags) -> Result<Cookie, MagicError> {
-        let cookie;
-        unsafe {
-            cookie = self::libmagic::magic_open((flags | self::CookieFlags::ERROR).bits());
-        }
-        if cookie.is_null() {
-            Err(self::ffi::LibmagicError::Open {
-                errno: errno::errno(),
-            }
-            .into())
-        } else {
-            Ok(Cookie { cookie })
+        match self::ffi::open(flags.bits()) {
+            Err(err) => Err(err.into()),
+            Ok(cookie) => Ok(Cookie { cookie }),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@
 //! This crate has not been audited nor is it ready for production use.
 //!
 
+#![warn(unsafe_code)]
+
 extern crate libc;
 extern crate magic_sys as libmagic;
 #[macro_use]
@@ -80,6 +82,8 @@ use std::path::Path;
 use std::ptr;
 use std::str;
 use thiserror::Error;
+
+mod ffi;
 
 bitflags! {
     /// Bitmask flags that specify how `Cookie` functions should behave
@@ -303,7 +307,7 @@ impl Drop for Cookie {
     /// Closes the magic database and deallocates any resources used
     #[doc(alias = "magic_close")]
     fn drop(&mut self) {
-        unsafe { self::libmagic::magic_close(self.cookie) }
+        self::ffi::close(self.cookie);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,20 +348,11 @@ impl Cookie {
     /// Check the validity of entries in the database `filenames`
     #[doc(alias = "magic_check")]
     pub fn check<P: AsRef<Path>>(&self, filenames: &[P]) -> Result<(), MagicError> {
-        let cookie = self.cookie;
         let db_filenames = db_filenames(filenames)?;
-        let ret;
 
-        unsafe {
-            ret = self::libmagic::magic_check(
-                cookie,
-                db_filenames.map_or_else(ptr::null, |c| c.into_raw()),
-            );
-        }
-        if 0 == ret {
-            Ok(())
-        } else {
-            Err(self.magic_failure())
+        match self::ffi::check(self.cookie, db_filenames.as_deref()) {
+            Err(err) => Err(err.into()),
+            Ok(_) => Ok(()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,16 +321,9 @@ impl Cookie {
     /// Returns a textual description of the contents of the `buffer`
     #[doc(alias = "magic_buffer")]
     pub fn buffer(&self, buffer: &[u8]) -> Result<String, MagicError> {
-        let buffer_len = buffer.len() as size_t;
-        let pbuffer = buffer.as_ptr();
-        unsafe {
-            let str = self::libmagic::magic_buffer(self.cookie, pbuffer, buffer_len);
-            if str.is_null() {
-                Err(self.magic_failure())
-            } else {
-                let slice = CStr::from_ptr(str).to_bytes();
-                Ok(str::from_utf8(slice).unwrap().to_string())
-            }
+        match self::ffi::buffer(self.cookie, buffer) {
+            Ok(res) => Ok(res.to_string_lossy().to_string()),
+            Err(err) => Err(err.into()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,8 +273,6 @@ pub enum MagicError {
     LibmagicFlagUnsupported(CookieFlags),
     #[error("invalid database file path")]
     InvalidDatabaseFilePath,
-    #[error("unknown error")]
-    Unknown,
 }
 
 impl From<self::ffi::LibmagicError> for MagicError {


### PR DESCRIPTION
This adds a new private `ffi` module that contains all the `unsafe` code required to interact with `magic_sys` / `libmagic`.
Due to FFI, some `unsafe` will always be needed, so no fancy [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/) badge is possible.

This is a semver breaking change since it changes the public `MagicError` error type / API.

In theory, this module could be public or its own crate, but people will probably either use the high-level `magic` crate API or the low-level `magic-sys` crate.

The `libmagic` documentation is incomplete, so the API violations might need some research. Unsure if that should result in automated tests.