### PR TITLE
OpenSSF best practices (badge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-rust-magic [![linux build status](https://github.com/robo9k/rust-magic/actions/workflows/linux.yml/badge.svg)](https://github.com/robo9k/rust-magic/actions/workflows/linux.yml) [![Documentation](https://docs.rs/magic/badge.svg)](https://docs.rs/magic) [![REUSE status](https://api.reuse.software/badge/github.com/robo9k/rust-magic)](https://api.reuse.software/info/github.com/robo9k/rust-magic)
+rust-magic [![linux build status](https://github.com/robo9k/rust-magic/actions/workflows/linux.yml/badge.svg)](https://github.com/robo9k/rust-magic/actions/workflows/linux.yml) [![Documentation](https://docs.rs/magic/badge.svg)](https://docs.rs/magic) [![REUSE status](https://api.reuse.software/badge/github.com/robo9k/rust-magic)](https://api.reuse.software/info/github.com/robo9k/rust-magic) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5709/badge)](https://bestpractices.coreinfrastructure.org/projects/5709)
 ==========
 [libmagic](https://www.darwinsys.com/file/) bindings for [Rust](https://www.rust-lang.org/).
 


### PR DESCRIPTION
This adds an Open Source Security Foundation (OpenSSF) best practices badge: [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5709/badge)](https://bestpractices.coreinfrastructure.org/projects/5709)

The overall progress is tracked in #48 