### PR TITLE
Fix permissions for right workflow job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,6 @@ env:
 
 jobs:
   cargo-fmt:
-    permissions:
-      checks: write # for actions-rs/clippy-check to write checks
     runs-on: ubuntu-latest
 
     steps:
@@ -32,6 +30,8 @@ jobs:
         args: --all -- --check
 
   cargo-clippy:
+    permissions:
+      checks: write # for actions-rs/clippy-check to write checks
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
As noted in https://github.com/robo9k/rust-magic/pull/51#issuecomment-1218343384 `actions-rs/clippy-check` broke, most likely since I can't read properly and added the permissions to the wrong workflow job.