### PR TITLE
Update to Rust edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ exclude = [
 	"LICENSES/",
 	".reuse/",
 ]
+edition = "2018"
 rust-version = "1.48"
 
 [package.metadata]


### PR DESCRIPTION
See https://doc.rust-lang.org/edition-guide/rust-2018/index.html

Rust edition 2018 requires Rust v1.13, current MSRV is v1.48 already.

This should be a semver compatible change.