### PR TITLE
Implement `magic_version()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,4 @@ version = "0.2.105"
 default-features = false
 
 [dev-dependencies]
-regex = "1.5.4"
 static_assertions = "1.1.0"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -234,3 +234,7 @@ pub(crate) fn open(flags: libc::c_int) -> Result<libmagic::magic_t, LibmagicErro
         Ok(cookie)
     }
 }
+
+pub(crate) fn version() -> libc::c_int {
+    unsafe { libmagic::magic_version() }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,18 +220,6 @@ bitflags::bitflags! {
     }
 }
 
-/// Returns the version of this crate in the format `MAJOR.MINOR.PATCH`.
-pub fn version() -> &'static str {
-    // TODO: There's also an optional _PRE part
-    concat!(
-        env!("CARGO_PKG_VERSION_MAJOR"),
-        ".",
-        env!("CARGO_PKG_VERSION_MINOR"),
-        ".",
-        env!("CARGO_PKG_VERSION_PATCH"),
-    )
-}
-
 fn db_filenames<P: AsRef<Path>>(filenames: &[P]) -> Result<Option<CString>, MagicError> {
     match filenames.len() {
         0 => Ok(None),
@@ -421,8 +409,6 @@ impl Cookie {
 
 #[cfg(test)]
 mod tests {
-    extern crate regex;
-
     use super::Cookie;
     use super::CookieFlags;
     use super::MagicError;
@@ -502,12 +488,6 @@ mod tests {
         assert!(cookie
             .load(&vec!["data/tests/db-images-png", "data/tests/db-python",])
             .is_ok());
-    }
-
-    #[test]
-    fn version() {
-        let version_regex = regex::Regex::new(r"\d+\.\d+.\d+").unwrap();
-        assert!(version_regex.is_match(super::version()));
     }
 
     static_assertions::assert_impl_all!(Cookie: std::fmt::Debug);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,15 @@ use magic_sys as libmagic;
 
 mod ffi;
 
+/// Returns the version of the `libmagic` C library as reported by itself.
+///
+/// # Examples
+/// A version of "5.41" is returned as `541`.
+#[doc(alias = "magic_version")]
+pub fn libmagic_version() -> libc::c_int {
+    crate::ffi::version()
+}
+
 bitflags::bitflags! {
     /// Bitmask flags that specify how `Cookie` functions should behave
     ///
@@ -505,5 +514,12 @@ mod tests {
             cookie.file(&path).ok().unwrap(),
             "PNG image data, 128 x 128, 8-bit/color RGBA, non-interlaced"
         );
+    }
+
+    #[test]
+    fn libmagic_version() {
+        let version = super::libmagic_version();
+
+        assert!(version > 500);
     }
 }


### PR DESCRIPTION
See #4 

* Removes `magic::version()` as there's no real need for it.
This is a semver breaking change.
* Adds `magic::libmagic_version()`