### PR TITLE
Release v0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ authors = [
 	"Onur Aslan <onur@onur.im>",
 	"robo9k <robo9k@symlink.io>",
 ]
-version = "0.13.0"
+version = "0.14.0"
 include = [
 	"/src/",
 ]


### PR DESCRIPTION
Previous released version is v0.13.0

Changes
- #54 
- #56 
- #57 
- #59 
- #63 
- #62 
- #64 
- #65 

Removing [`magic::version()`](https://docs.rs/magic/0.13.0/magic/fn.version.html) is a semver breaking change, thus v0.14