### PR TITLE
Use conventional commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,24 @@
+permissions:
+    contents: read
+
+on:
+    pull_request:
+        branches: [ main ]
+
+jobs:
+    check-commits:
+        # https://github.com/cocogitto/cocogitto-action
+        runs-on: ubuntu-latest
+        name: check conventional commit compliance
+        steps:
+            - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+              with:
+                fetch-depth: 0
+                # pick the pr HEAD instead of the merge commit
+                ref: ${{ github.event.pull_request.head.sha }}
+
+            - uses: taiki-e/install-action@5b205dd5b807eef56fdbfeedeedcee63c5d44090 # v2.18.16
+              with:
+                tool: cocogitto@5.5.0
+
+            - run: cog check ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Start using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and enforce it using GitHub Actions CI.

This should also allow better integration with other tooling, e.g. creating changelogs, detecting semver changes, publishing releases.

Commit messages before `v0.14.0` do not comply, but history in the default "main" branch must not be rewritten.