### PR TITLE
Cleanup old release configuration

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,0 @@
-[bumpversion]
-current_version = 0.12.2
-commit = True
-tag = True
-
-[bumpversion:file:Cargo.toml]
-search = version = "{current_version}"
-replace = version = "{new_version}"
-

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,10 +7,6 @@ Files: Cargo.toml README.md LICENSE.md CONTRIBUTING.md CHANGELOG.md
 Copyright: © The `magic` Rust crate authors
 License: MIT OR Apache-2.0
 
-Files: .bumpversion.cfg
-Copyright: © The `magic` Rust crate authors
-License: MIT OR Apache-2.0
-
 Files: .github/workflows/* clippy.toml deny.toml rust-toolchain.toml
 Copyright: © The `magic` Rust crate authors
 License: MIT OR Apache-2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
 
 ## 0.14.0 - 2023-09-16
 


### PR DESCRIPTION
Fix changelog from #72 so that #70 does not add duplicate content.
Remove unused `.bumpversion.cfg` now that `release-plz` is used.