### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,15 +1,17 @@
-permissions:
-    contents: read
+name: cog check
+
+permissions: {}
 
 on:
     pull_request:
         branches: [ main ]
 
 jobs:
-    check-commits:
-        # https://github.com/cocogitto/cocogitto-action
-        runs-on: ubuntu-latest
+    check-conventional-commits:
         name: check conventional commit compliance
+        permissions:
+          contents: read
+        runs-on: ubuntu-22.04
         steps:
             - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
               with:

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,7 +1,6 @@
 name: cargo deny
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   push:
@@ -22,7 +21,9 @@ env:
 
 jobs:
   cargo-deny:
-    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         checks:
@@ -36,8 +37,8 @@ jobs:
     - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
       with:
         egress-policy: audit
-    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
-    - uses: EmbarkStudios/cargo-deny-action@7257a18a9c2fe3f92b85d41ae473520dff953c97 # v1.3.2
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+    - uses: EmbarkStudios/cargo-deny-action@a50c7d5f86370e02fae8472c398f15a36e517bb8 # v1.5.4
       with:
         command: check ${{ matrix.checks }}
         arguments: --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+name: release-plz
+
+permissions: {}
+
 on:
   push:
     branches:
@@ -5,7 +9,9 @@ on:
 
 jobs:
   release-plz:
-    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
     steps:
       - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
@@ -14,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
-      - uses: MarcoIeni/release-plz-action@63d791e17e2f2369d173fb6b81b401029e16e04f # v0.5.20
+      - uses: MarcoIeni/release-plz-action@ce393af6a01a1c994bf8a0f469c015dc5593dfbe # v0.5.23
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,17 +1,18 @@
-name: REUSE Compliance Check
+name: REUSE compliance check
 
-permissions:
-  contents: read
+permissions: {}
 
 on: [push, pull_request]
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps: 
     - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
       with:
         egress-policy: audit
-    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@e7a435374d26d54b324fa6699d8eafb076340dfd # v1.2.0
+      uses: fsfe/reuse-action@4f2804894b54004c8ed4b8a62b7c649e54a3aa4b # v2.0.0

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,12 +22,12 @@ jobs:
         with:
           egress-policy: audit
       - name: "Checkout code"
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@ce330fde6b1a5c9c75b417e7efc510b822a35564 # v1.1.2
+        uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031 # v2.2.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -36,7 +36,7 @@ jobs:
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: SARIF file
           path: results.sarif
@@ -44,6 +44,6 @@ jobs:
       
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # v1.0.26
+        uses: github/codeql-action/upload-sarif@6a28655e3dcb49cb0840ea372fd6d17733edd8a4 # v2.21.8 
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
This manually updates the workflows that can otherwise be kept as-is:
- new action versions
- empty top-level `permissions` where possible
- names where GitHub UI would otherwise be ugly
This does not touch workflows that need e.g. entirely different actions.