### PR TITLE
Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,13 +19,14 @@ jobs:
 
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 
-      - uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7 # doesn't have usual versioned releases/tags
+      - id: toolchain
+        uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7 # doesn't have usual versioned releases/tags
         with:
           toolchain: nightly # minimal profile includes rustc component which includes cargo and rustdoc
 
-      - run: cargo doc --verbose --no-deps --all-features
+      - run: cargo +${{ steps.toolchain.outputs.name }} doc --verbose --no-deps --all-features
         env:
-          RUSTDOCFLAGS: --crate-version ${{ github.event.push.after }} -Z unstable-options --enable-index-page
+          RUSTDOCFLAGS: --crate-version ${{ github.event.after }} -Z unstable-options --enable-index-page
 
       - uses: actions/configure-pages@f156874f8191504dae5b037505266ed5dda6c382 # v3.0.6
 


### PR DESCRIPTION
Fix running `cargo doc` with the `+nightly` instead of `rust-toolchain.toml` version.
Fix `github.event` variable.

Both issues were introduced in #79 