### PR TITLE
Always run `cargo deny` CI workflow

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -3,18 +3,7 @@ name: cargo deny
 permissions: {}
 
 on:
-  push:
-    branches: [ main ]
-    paths: 
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '.github/workflows/deny.yml'
   pull_request:
-    branches: [ main ]
-    paths: 
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '.github/workflows/deny.yml'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
If limited to certain paths, it (or some of its matrix jobs) can not be used as a required status.