### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: friday
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: friday

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,7 +7,7 @@ Files: Cargo.toml README.md LICENSE.md CONTRIBUTING.md CHANGELOG.md SECURITY.md
 Copyright: © The `magic` Rust crate authors
 License: MIT OR Apache-2.0
 
-Files: .github/workflows/* clippy.toml deny.toml rust-toolchain.toml
+Files: .github/workflows/* .github/dependabot.yml clippy.toml deny.toml rust-toolchain.toml
 Copyright: © The `magic` Rust crate authors
 License: MIT OR Apache-2.0
 


### PR DESCRIPTION
This adds GitHub's Dependabot both for automated security and regular version updates.