### PR TITLE
Fix Dependabot configuration for conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,12 @@ updates:
     schedule:
       interval: weekly
       day: friday
+    commit-message:
+      prefix: chore(deps)
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
       day: friday
+    commit-message:
+      prefix: chore(deps)


### PR DESCRIPTION
Seems like autodetection from "recent" commits doesn't quite work.