### PR TITLE
Replace `errno` crate dependency with `std::io::Error`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ maintenance = { status = "passively-maintained" }
 bitflags = "1.3.2"
 magic-sys = "0.3.0"
 thiserror = "1.0.30"
-errno = "0.2.8"
 
 [dependencies.libc]
 version = "0.2.105"


### PR DESCRIPTION
This replaces the use of `errno::Errno` with `std::io::Error`, thus removing the need for the `errno` crate dependency.

This is a semver breaking change since `FfiError` and thus `MagicError` now indirectly no longer implement auto traits `UnwindSafe` and `RefUnwindSafe`.
The string representation of those errors might also differ now, but this might not be considered public API.
The `errno` field was not publically exposed otherwise previously (but maybe it should in future releases!).

This does not affect MSRV.