### PR TITLE
chore: release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1](https://github.com/robo9k/rust-magic/compare/v0.15.0...v0.15.1) - 2023-09-27
+
+### Other
+- Use `mold` linker
+- Fix docs workflow SHA for pull requests
+- *(deps)* Update `proc-macro2` dependency for nightly builds
+- Build docs on pull requests but do not deploy them
+- Add `Cargo.lock`
+- Run build workflow on push also
+- Add codecov badge to readme
+- Upload coverage to `codecov.io`
+- Report test coverage with `cargo-llvm-cov`
+- Fix CI build workflow badge in readme
+
 ## [0.15.0](https://github.com/robo9k/rust-magic/compare/v0.14.0...v0.15.0) - 2023-09-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "magic"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ authors = [
 	"Onur Aslan <onur@onur.im>",
 	"robo9k <robo9k@symlink.io>",
 ]
-version = "0.15.0"
+version = "0.15.1"
 include = [
 	"/src/",
 ]


### PR DESCRIPTION
## 🤖 New release
* `magic`: 0.15.0 -> 0.15.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.1](https://github.com/robo9k/rust-magic/compare/v0.15.0...v0.15.1) - 2023-09-27

### Other
- Use `mold` linker
- Fix docs workflow SHA for pull requests
- *(deps)* Update `proc-macro2` dependency for nightly builds
- Build docs on pull requests but do not deploy them
- Add `Cargo.lock`
- Run build workflow on push also
- Add codecov badge to readme
- Upload coverage to `codecov.io`
- Report test coverage with `cargo-llvm-cov`
- Fix CI build workflow badge in readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).