### PR TITLE
Run CI build workflow on push also

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: build
 permissions: {}
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
Seems like https://github.com/robo9k/rust-magic/pull/96#issuecomment-1735834281 was right and `codecov.io` coverage for `main` branch requires "on: push", even with linear history.