### PR TITLE
Build docs on pull requests but do not deploy them

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: docs
 permissions: {}
 
 on:
+  pull_request: 
   push:
     branches:
       - main
@@ -41,6 +42,7 @@ jobs:
           path: target/doc/
 
   deploy-pages:
+    if: github.event_name == 'push'
     permissions:
       id-token: write
       pages: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
This way breakage should occur early, e.g. dependency not working on nightly.

#98 "downgraded" `proc-macro2` so the MSRV build passed while the nightly doc build failed lateron.