### PR TITLE
Fix docs CI workflow SHA for pull requests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
 
       - run: cargo +${{ steps.toolchain.outputs.name }} doc --verbose --no-deps --all-features
         env:
-          RUSTDOCFLAGS: --crate-version ${{ github.event.after }} -Z unstable-options --enable-index-page
+          RUSTDOCFLAGS: --crate-version ${{ github.event.pull_request.head.sha || github.sha }} -Z unstable-options --enable-index-page
 
       - uses: actions/configure-pages@f156874f8191504dae5b037505266ed5dda6c382 # v3.0.6
 


### PR DESCRIPTION
Looks like #99 broke for pull requests, where initially `github.event.after` is empty.
The GitHub docs aren't entirely clear on what `github.sha` is, other than that it depends on the event type.
For pull requests, the `--crate--version` doesn't really matter as we don't actually publish it.