### PR TITLE
Reconfigure `release-plz`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,16 @@ jobs:
       - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:
           egress-policy: audit
+      - uses: actions/create-github-app-token@49ce228ea7cddec9f88dd09c5b7740dbac82d7ba # v1.2.1 
+        id: app-token
+        with:
+          app_id: ${{ vars.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - uses: MarcoIeni/release-plz-action@ce393af6a01a1c994bf8a0f469c015dc5593dfbe # v0.5.23
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,7 +7,7 @@ Files: Cargo.toml Cargo.lock README.md LICENSE.md CONTRIBUTING.md CHANGELOG.md S
 Copyright: © The `magic` Rust crate authors
 License: MIT OR Apache-2.0
 
-Files: .github/workflows/* .github/dependabot.yml clippy.toml deny.toml rust-toolchain.toml
+Files: .github/workflows/* .github/dependabot.yml clippy.toml deny.toml release-plz.toml rust-toolchain.toml
 Copyright: © The `magic` Rust crate authors
 License: MIT OR Apache-2.0
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,2 @@
+[workspace]
+pr_labels = ["release"]


### PR DESCRIPTION
This uses a private GitHub App instead of a PAT.
Also add the "release" label to pull requests.