### PR TITLE
Fix clippy findings in rustdoc

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,3 +47,32 @@ jobs:
           components: clippy # minimal profile does not include it
 
       - run: cargo +${{ steps.toolchain.outputs.name }} clippy --all-targets --all-features
+
+  cargo-rustdoc-clippy:
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - id: toolchain
+        uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7 # doesn't have usual versioned releases/tags
+        with:
+          toolchain: nightly
+          components: clippy # minimal profile does not include it
+
+      # dependency of cargo-rustdoc-clippy
+      - run: |
+          sudo apt-get update
+          sudo apt-get install zsh
+
+      # https://github.com/rust-lang/rust/issues/56232#issuecomment-1248359946
+      - run: |
+          curl --output ~/.cargo/bin/cargo-rustdoc-clippy https://raw.githubusercontent.com/Nemo157/dotfiles/e6daf083068ff17d14b19dc2569ae62ea86bf23c/bin/cargo-rustdoc-clippy
+          chmod +x ~/.cargo/bin/cargo-rustdoc-clippy
+
+      - run: cargo +${{ steps.toolchain.outputs.name }} rustdoc-clippy --all-features

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ fn file_example() -> Result<(), magic::MagicError> {
     let cookie = magic::Cookie::open(magic::CookieFlags::ERROR)?;
 
     // Load a specific database (so exact text assertion below works regardless of the system's default database)
-    cookie.load(&vec!["data/tests/db-images-png"])?;
+    cookie.load(&["data/tests/db-images-png"])?;
 
     let file = "data/tests/rust-logo-128x128-blk.png";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,14 +38,14 @@
 //! let cookie = magic::Cookie::open(magic::CookieFlags::ERROR)?;
 //!
 //! // Load a specific database (so exact text assertion below works regardless of the system's default database)
-//! cookie.load(&vec!["data/tests/db-images-png"])?;
+//! cookie.load(&["data/tests/db-images-png"])?;
 //! // You can instead load the default database
 //! //cookie.load::<&str>(&[])?;
 //!
 //! // Analyze a test file
 //! let file_to_analyze = "data/tests/rust-logo-128x128-blk.png";
 //! let expected_analysis_result = "PNG image data, 128 x 128, 8-bit/color RGBA, non-interlaced";
-//! assert_eq!(cookie.file(&file_to_analyze)?, expected_analysis_result);
+//! assert_eq!(cookie.file(file_to_analyze)?, expected_analysis_result);
 //! # Ok(())
 //! # }
 //! ```
@@ -441,7 +441,7 @@ impl Cookie {
     /// cookie.load::<&str>(&[])?;
     ///
     /// // Load databases from files
-    /// cookie.load(&vec!["data/tests/db-images-png", "data/tests/db-python"])?;
+    /// cookie.load(&["data/tests/db-images-png", "data/tests/db-python"])?;
     /// # Ok(())
     /// # }
     #[doc(alias = "magic_load")]


### PR DESCRIPTION
As an extension of #107 also find and fix clippy findings in rustdoc.
Adds unofficial `cargo-rustdoc-clippy` as a CI lint job.

Like before, #43 probably would have more.