### PR TITLE
Refactor CI workflow names and events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,20 @@
-name: build
+name: "build"
 
 permissions: {}
 
 on:
+  # run "test" job on push events as well to get main branch coverage
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
+    name: "cargo build"
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
     runs-on: ubuntu-22.04
@@ -36,7 +38,7 @@ jobs:
       - run: cargo +${{ steps.toolchain.outputs.name }} build --all-targets --all-features --verbose
 
   test:
-    name: "test (with coverage)"
+    name: "cargo test (with coverage)"
     permissions:
       contents: read
     runs-on: ubuntu-22.04
@@ -81,7 +83,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-careful:
-    name: "test (carefully)"
+    if: github.event_name == 'pull_request'
+    name: "cargo test (carefully)"
     permissions:
       contents: read
     runs-on: ubuntu-22.04

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,14 +1,13 @@
-name: cog check
+name: "conventional commits"
 
 permissions: {}
 
 on:
-    pull_request:
-        branches: [ main ]
+  pull_request:
 
 jobs:
-    check-conventional-commits:
-        name: check conventional commit compliance
+    cog-check:
+        name: "cog check"
         permissions:
           contents: read
         runs-on: ubuntu-22.04

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,4 +1,4 @@
-name: cargo deny
+name: "deny"
 
 permissions: {}
 
@@ -10,6 +10,7 @@ env:
 
 jobs:
   cargo-deny:
+    name: "cargo deny"
     permissions:
       contents: read
     runs-on: ubuntu-22.04

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,15 +1,16 @@
-name: docs
+name: "docs"
 
 permissions: {}
 
 on:
   pull_request: 
+  # run "deploy-pages" job to deploy main branch to GitHub pages
   push:
-    branches:
-      - main
+    branches: [ "main" ]
 
 jobs:
   build-rustdoc:
+    name: "cargo doc"
     permissions:
       contents: read
     runs-on: ubuntu-22.04
@@ -42,6 +43,7 @@ jobs:
           path: target/doc/
 
   deploy-pages:
+    name: "deploy GitHub pages"
     if: github.event_name == 'push'
     permissions:
       id-token: write

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,16 @@
-name: lint
+name: "lint"
 
 permissions: {}
 
 on:
   pull_request:
-    branches: [ main ]
 
 env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
   cargo-fmt:
+    name: "cargo fmt"
     permissions:
       contents: read
     runs-on: ubuntu-22.04
@@ -30,6 +30,7 @@ jobs:
       - run: cargo +${{ steps.toolchain.outputs.name }} fmt --all --check
 
   cargo-clippy:
+    name: "cargo clippy"
     permissions:
       contents: read
     runs-on: ubuntu-22.04
@@ -49,6 +50,7 @@ jobs:
       - run: cargo +${{ steps.toolchain.outputs.name }} clippy --all-targets --all-features
 
   cargo-rustdoc-clippy:
+    name: "cargo rustdoc-clippy"
     permissions:
       contents: read
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,10 @@
-name: release-plz
+name: "release-plz"
 
 permissions: {}
 
 on:
   push:
-    branches:
-      - main
+    branches: [ "main" ]
 
 jobs:
   release-plz:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,11 +1,16 @@
-name: REUSE compliance check
+name: "REUSE"
 
 permissions: {}
 
-on: [push, pull_request]
+on:
+  # also run on push to main branch for badge
+  push:
+    branches: [ main ]
+  pull_request:
 
 jobs:
-  test:
+  lint:
+    name: "reuse lint"
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,4 +1,4 @@
-name: Scorecards supply-chain security
+name: "scorecards"
 
 permissions: read-all
 
@@ -11,7 +11,7 @@ on:
 
 jobs:
   analysis:
-    name: Scorecards analysis
+    name: "scorecards analysis"
     runs-on: ubuntu-latest
     permissions:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results


### PR DESCRIPTION
This should make it more clear and succint what workflow and job was run.
Only run jobs on `push` or `pull_request` events where needed.