### PR TITLE
Use typestate for opened/loaded cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ fn file_example() -> Result<(), Box<dyn std::error::Error>> {
     let cookie = magic::Cookie::open(magic::CookieFlags::ERROR)?;
 
     // Load a specific database (so exact text assertion below works regardless of the system's default database)
-    cookie.load(&["data/tests/db-images-png"])?;
+    let cookie = cookie.load(&["data/tests/db-images-png"])?;
 
     let file = "data/tests/rust-logo-128x128-blk.png";
 

--- a/examples/file-ish.rs
+++ b/examples/file-ish.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cookie = magic::Cookie::open(magic::CookieFlags::ERROR)?;
 
     // Load the system's default database
-    cookie.load::<&str>(&[])?;
+    let cookie = cookie.load::<&str>(&[])?;
 
     let file = std::env::args_os()
         .nth(1)


### PR DESCRIPTION
This uses typestate so you can only call `Cookie::file` and `Cookie::buffer` after `Cookie::load`.

This idea initially came up in https://github.com/robo9k/rust-magic/issues/6#issuecomment-293592609
This does not implement a builder for `Cookie`.