### PR TITLE
Use precise version for `bitflags` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ targets = []
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-bitflags = "2"
+bitflags = "2.4.0"
 magic-sys = "0.3.0"
 thiserror = "1.0.50"
 


### PR DESCRIPTION
**References**
N/A

**Description**
Use a precise version for all dependencies, so users end up with the same as in `Cargo.lock`.
This doesn't update the `bitflags` dependency, there's e.g. #156 for that.
