### PR TITLE
Use regular `release-plz-action` version again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: MarcoIeni/release-plz-action@5c035ca231f363d920a95483bece00036c6e55a6 # https://github.com/MarcoIeni/release-plz-action/pull/85
+      - uses: MarcoIeni/release-plz-action@045c7a41711fb0696141464d001f9c3fe85f912e # v0.5.25
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
**References**
#142 

**Description**
This switches from a specific revision of `release-plz-action` back to the next regular tagged revision that dependabot can update.
