### PR TITLE
chore(deps): Bump cargo-deny from 0.14.3 to 0.14.19

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -39,6 +39,6 @@ jobs:
 
     - uses: taiki-e/install-action@3d5321a5e3ceb69232a18ca12966908a643cbce3 # v2.28.14
       with:
-        tool: cargo-deny@0.14.3
+        tool: cargo-deny@0.14.19
 
     - run: cargo +${{ steps.toolchain.outputs.name }} deny --log-level info --all-features check ${{ matrix.checks }}


### PR DESCRIPTION
**References**
Recent dependabot builds fail with:
```
2024-03-22 07:56:47 [INFO] gathering crates for /home/runner/work/rust-magic/rust-magic/Cargo.toml
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/krates-0.15.1/src/builder.rs:776:47
```

**Description**
This bumps `cargo-deny` to the latest version in the hope that this will fix the panick.
Unfortunately dependabot can't be configured to bump those pinned tools itself.
