### PR TITLE
chore(deps): Bump cargo-careful from 0.4.0 to 0.4.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: taiki-e/install-action@0eaa33a7adfb219fec683c2480a4eb8c79bfeff1 # v2.33.20
         with:
-          tool: cargo-careful@0.4.0
+          tool: cargo-careful@0.4.2
 
       - run: cargo +${{ steps.toolchain.outputs.name }} llvm-cov test --codecov --output-path codecov.json --all-targets --all-features --verbose
 
@@ -108,6 +108,6 @@ jobs:
 
       - uses: taiki-e/install-action@0eaa33a7adfb219fec683c2480a4eb8c79bfeff1 # v2.33.20
         with:
-          tool: cargo-careful@0.4.0
+          tool: cargo-careful@0.4.2
 
       - run: cargo +${{ steps.toolchain.outputs.name }} careful test --all-targets --all-features --verbose


### PR DESCRIPTION
**References**
CI fails with "cannot find 'ld'", see https://github.com/RalfJung/cargo-careful/issues/31

**Description**
Update `cargo-careful` to the latest version, `0.4.2`, that contains the fix.

Long-term this should probably be done indirectly by using a pinned `taiki-e/install-action` and then `cargo-careful@latest`.
