### PR TITLE
Link to alternative pure Rust crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,9 @@
 //!
 //! Maybe you want to know if a file contains other, malicious content?
 //! In this case you should use an anti-virus software, e.g. [ClamAV](https://www.clamav.net/), [Virus Total](https://www.virustotal.com/).
+//!
+//! Maybe you need to support platforms that are tricky with the `libmagic` C library, e.g. wasm32?
+//! In this case you could use pure Rust alternatives, e.g. the [`file_type` crate](https://crates.io/crates/file_type).
 
 #![deny(unsafe_code)]
 


### PR DESCRIPTION
**References**
The similar `file_type` crate added benchmarks against `magic` and a link in https://github.com/theseus-rs/file-type/issues/71 so this returns the favor.

**Description**
Extend existing list of use cases in crate doc with link to alternative pure Rust crate
