### PR TITLE
chore(deps): Bump cocogitto from 5.5.0 to 6.2.0

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -24,6 +24,6 @@ jobs:
 
             - uses: taiki-e/install-action@3eb90b20bc1fe55dfbf30d81d4a7e0ef8dd34caa # v2.36.0
               with:
-                tool: cocogitto@5.5.0
+                tool: cocogitto@6.2.0
 
             - run: cog check ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
**References**
Current workflow hits the following error:
```
ambiguous SHA1 prefix - found multiple offsets for pack entry; class=Odb (9); code=Ambiguous (-5)
```
This was fixed in cocogitto v6

**Description**
Bump cocogitto version so conventional commits CI workflow works again.
