### PR TITLE
chore(deps): Bump cargo-careful from 0.4.2 to 0.4.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,6 @@ jobs:
 
       - uses: taiki-e/install-action@3eb90b20bc1fe55dfbf30d81d4a7e0ef8dd34caa # v2.36.0
         with:
-          tool: cargo-careful@0.4.2
+          tool: cargo-careful@0.4.3
 
       - run: cargo +${{ steps.toolchain.outputs.name }} careful test --all-targets --all-features --verbose


### PR DESCRIPTION
**References**
Current workflow fails with error:
```
Preparing a careful sysroot (target: x86_64-unknown-linux-gnu)... thread 'main' panicked at src/main.rs:267:10:
failed to build sysroot; run `cargo careful setup` to see what went wrong: failed to copy lockfile from sysroot source
```
This was fixed in cargo-careful v0.4.3

**Description**
Bump cargo-careful version so careful CI workflow works again.
