### PR TITLE
Update `cargo deny` CI workflow from `magic-sys` repo

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,9 +1,20 @@
-name: "deny"
+name: "cargo deny"
 
 permissions: {}
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/deny.yml'
   pull_request:
+    branches: [ main ]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/deny.yml'
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,7 +24,7 @@ jobs:
     name: "cargo deny"
     permissions:
       contents: read
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         checks:
@@ -24,21 +35,15 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
-    - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+    - uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-
-    - id: toolchain
-      uses: dtolnay/rust-toolchain@d8352f6b1d2e870bc5716e7a6d9b65c4cc244a1a # doesn't have usual versioned releases/tags
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
-        toolchain: "stable"
+        persist-credentials: false
 
-    - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
-
-    - uses: taiki-e/install-action@3eb90b20bc1fe55dfbf30d81d4a7e0ef8dd34caa # v2.36.0
+    - uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
       with:
-        tool: cargo-deny@0.14.19
-
-    - run: cargo +${{ steps.toolchain.outputs.name }} deny --log-level info --all-features check ${{ matrix.checks }}
+        command: check ${{ matrix.checks }}
+        arguments: --all-features

--- a/deny.toml
+++ b/deny.toml
@@ -4,10 +4,13 @@ allow = [
     "Apache-2.0",
     "Unicode-DFS-2016", # see https://github.com/dtolnay/unicode-ident/pull/11#pullrequestreview-1066127930
 ]
-copyleft = "deny"
 
 [bans]
 wildcards = "deny"
+#external-default-features = "deny"
+
+[bans.build]
+#allow-build-scripts = []
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
**References**
none, general bitrot in this repo

**Description**
Use the improved `cargo deny` CI workflow from `magic-sys`, which includes newer dependencies and some but not all best practices