### PR TITLE
Remove `static_assertions` dev dependency, re-add test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,6 @@ dependencies = [
  "bitflags",
  "libc",
  "magic-sys",
- "static_assertions",
  "thiserror",
 ]
 
@@ -52,12 +51,6 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,3 @@ thiserror = "1.0.61"
 [dependencies.libc]
 version = "0.2.155"
 default-features = false
-
-[dev-dependencies]
-static_assertions = "1.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1158,6 +1158,7 @@ pub use crate::cookie::Cookie;
 #[cfg(test)]
 mod tests {
     use super::cookie::Flags;
+    use super::cookie::{Load, Open};
     use super::Cookie;
     use std::convert::TryInto;
 
@@ -1234,8 +1235,12 @@ mod tests {
         assert!(cookie.load(databases).is_ok());
     }
 
-    // TODO:
-    //static_assertions::assert_impl_all!(Cookie<S>: std::fmt::Debug);
+    #[test]
+    fn impl_debug() {
+        fn assert_debug<T: std::fmt::Debug>() {}
+        assert_debug::<Cookie<Open>>();
+        assert_debug::<Cookie<Load>>();
+    }
 
     #[test]
     #[ignore] // FIXME: the binary .mgc file depends on libmagic (internal format) version


### PR DESCRIPTION
**References**
none

**Description**
The `static_assertions` dev dependency was only used to assert that `Cookie` implements `Debug`, but that code got deactivated when typestate was added in #121 
Checking this is a one-liner, no dependency needed
Due to generics, just check the 2 states manually
