### PR TITLE
Use `chore` semantic commit type for lockfile updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
     "config:recommended",
     ":semanticCommits",
     "robo9k/renovate-config:crateSemanticCommitTypeFix",
+    "robo9k/renovate-config:crateLockfileSemanticCommitTypeChore",
   ],
   customManagers: [
     {


### PR DESCRIPTION
**References**
https://github.com/robo9k/rust-magic/issues/395#issue-3435425922

**Description**
Use "chore" instead of "fix" semantic commit type for lockfile updates
